### PR TITLE
geom_alt props

### DIFF
--- a/data/421/190/647/421190647.geojson
+++ b/data/421/190/647/421190647.geojson
@@ -599,6 +599,9 @@
     },
     "wof:country":"BH",
     "wof:created":1459009664,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17432b2641055647a768c8c6172aba8d",
     "wof:hierarchy":[
         {
@@ -609,7 +612,7 @@
         }
     ],
     "wof:id":421190647,
-    "wof:lastmodified":1566614350,
+    "wof:lastmodified":1582345713,
     "wof:name":"Manama",
     "wof:parent_id":85669053,
     "wof:placetype":"locality",

--- a/data/856/321/67/85632167.geojson
+++ b/data/856/321/67/85632167.geojson
@@ -997,7 +997,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"us-dshiu",
@@ -1072,7 +1071,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582345713,
+    "wof:lastmodified":1583224613,
     "wof:name":"Bahrain",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/321/67/85632167.geojson
+++ b/data/856/321/67/85632167.geojson
@@ -997,6 +997,7 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"us-dshiu",
@@ -1052,6 +1053,11 @@
     },
     "wof:country":"BH",
     "wof:country_alpha3":"BHR",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce621faa66431a5e1a5ce27ef121e432",
     "wof:hierarchy":[
         {
@@ -1066,7 +1072,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566614340,
+    "wof:lastmodified":1582345713,
     "wof:name":"Bahrain",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/690/39/85669039.geojson
+++ b/data/856/690/39/85669039.geojson
@@ -237,6 +237,9 @@
         "wd:id":"Q838532"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d15463623c512a65f824538b04c380f4",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566614340,
+    "wof:lastmodified":1582345713,
     "wof:name":"Southern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/43/85669043.geojson
+++ b/data/856/690/43/85669043.geojson
@@ -251,6 +251,9 @@
         "wd:id":"Q840445"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d92649a7004e1f838e92e107e6735afc",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345713,
     "wof:name":"Northern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/53/85669053.geojson
+++ b/data/856/690/53/85669053.geojson
@@ -260,6 +260,9 @@
         "wd:id":"Q528953"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38d16f59a700e602393b3433d7366fc9",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566614340,
+    "wof:lastmodified":1582345713,
     "wof:name":"Capital",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/59/85669059.geojson
+++ b/data/856/690/59/85669059.geojson
@@ -294,6 +294,9 @@
         "wd:id":"Q375630"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f7d34b93b7b88f3de969de715e68855",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345713,
     "wof:name":"Muharraq",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/859/030/61/85903061.geojson
+++ b/data/859/030/61/85903061.geojson
@@ -87,6 +87,10 @@
         "wk:page":"Ghuraifa"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1684235b973bc76d7bb11386b99921b6",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614334,
+    "wof:lastmodified":1582345711,
     "wof:name":"Al Ghurayfah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/63/85903063.geojson
+++ b/data/859/030/63/85903063.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1119964
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e06b807c7b68be7770d2f7f122f5e546",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345711,
     "wof:name":"\u062c\u0641\u064a\u0631",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/67/85903067.geojson
+++ b/data/859/030/67/85903067.geojson
@@ -67,6 +67,10 @@
         "wd:id":"Q6734831"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be7b4be91331c66e9f022ab7a6661f8e",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614334,
+    "wof:lastmodified":1582345711,
     "wof:name":"\u0627\u0644\u0645\u0627\u062d\u0648\u0632",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/69/85903069.geojson
+++ b/data/859/030/69/85903069.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1083636
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cdb8e6d1872d086b25d98ba40d7d877",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614334,
+    "wof:lastmodified":1582345711,
     "wof:name":"A\u015f \u015e\u0101lih\u0327\u012byah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/71/85903071.geojson
+++ b/data/859/030/71/85903071.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":984005
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"88a85ba894921efb432942c1550f4af0",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345711,
     "wof:name":"Bil\u0101d al Qad\u012bm",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/73/85903073.geojson
+++ b/data/859/030/73/85903073.geojson
@@ -87,6 +87,10 @@
         "wd:id":"Q4982050"
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c6bad55b16a9f0066d539f04090928b",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345711,
     "wof:name":"\u0628\u0648 \u0639\u0634\u064a\u0631\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/75/85903075.geojson
+++ b/data/859/030/75/85903075.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":44475
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27daff525a2f9e18cc36ecd4cdd1dc49",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345711,
     "wof:name":"Jabalat al Burh\u00e5mah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/77/85903077.geojson
+++ b/data/859/030/77/85903077.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":1168221
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c9b7bc3365f63951d0c7a8c49da4cb2",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345711,
     "wof:name":"Umm Ash Sha\u2019\u016bm",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/71/85907371.geojson
+++ b/data/859/073/71/85907371.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":237766
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7ebc6bd5c30e6ef6b5048ec1d940b8bd",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Al Mukharqa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/75/85907375.geojson
+++ b/data/859/073/75/85907375.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1086009
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25cfd59924746519fef7db61aa8ad600",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Al Qudaybiyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/77/85907377.geojson
+++ b/data/859/073/77/85907377.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":347081
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa71836d869438f0f879678505ec192b",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"As Saqiyyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/41/85932141.geojson
+++ b/data/859/321/41/85932141.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":273413
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c412c94d5ca150fe96ebfbb4f09fb4e4",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345712,
     "wof:name":"Barbar-block 528",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/45/85932145.geojson
+++ b/data/859/321/45/85932145.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":991475
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02a6552d3539c054d2bf0b9b417bd838",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 101",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/49/85932149.geojson
+++ b/data/859/321/49/85932149.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":991476
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba7adcd498718f951057254f22c6b875",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345713,
     "wof:name":"Sanabis-block 408",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/51/85932151.geojson
+++ b/data/859/321/51/85932151.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986741
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"53d7d3cdca42511eaca8b69cfa9cd4bb",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Zallaq-block 1055",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/57/85932157.geojson
+++ b/data/859/321/57/85932157.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":986742
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f917ed70ec5ba35b07aae9eefa230892",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Busaytin-block 228",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/61/85932161.geojson
+++ b/data/859/321/61/85932161.geojson
@@ -62,6 +62,10 @@
         "qs_pg:id":486825
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4b2c00c15f42372f7293871cd5b0e48",
     "wof:hierarchy":[
         {
@@ -76,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Muharraq City-block 215",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/65/85932165.geojson
+++ b/data/859/321/65/85932165.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":249377
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba754a1360a36674cc34a14db0ab0b1b",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345712,
     "wof:name":"Janabiah-block 569",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/69/85932169.geojson
+++ b/data/859/321/69/85932169.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":18220
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"25ae56bf7833640f25d2e0681c28105f",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 428",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/75/85932175.geojson
+++ b/data/859/321/75/85932175.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1033093
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d754324c6cbf0992eca7dfb0e01d92eb",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 305",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/83/85932183.geojson
+++ b/data/859/321/83/85932183.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1090202
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"40d4945ed475a17531c4d51f75019d21",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345713,
     "wof:name":"\u0645\u062c\u0645\u0639 322",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/87/85932187.geojson
+++ b/data/859/321/87/85932187.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1332730
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a7620be81db209ffc92b1554bfe3e77e",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345712,
     "wof:name":"Muharraq City-block 207",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/93/85932193.geojson
+++ b/data/859/321/93/85932193.geojson
@@ -65,6 +65,10 @@
         "qs_pg:id":1332735
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"527d1dc0b9e61664664342e1e4ffbed6",
     "wof:hierarchy":[
         {
@@ -79,7 +83,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Karbabad-block 436",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/321/97/85932197.geojson
+++ b/data/859/321/97/85932197.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1332731
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"727e688b92119ebe9d096c678f4ed924",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614339,
+    "wof:lastmodified":1582345712,
     "wof:name":"Muharraq City-block 209",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/01/85932201.geojson
+++ b/data/859/322/01/85932201.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1295834
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e526256d94d0696477087af26dfaedd",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"Karrana-block 460",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/05/85932205.geojson
+++ b/data/859/322/05/85932205.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":991480
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4d3484fd60c472a7ae5a15565082ee0",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"Wadi-block 1211",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/11/85932211.geojson
+++ b/data/859/322/11/85932211.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":1295832
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e74a156bcc720bda31687ca77d5ab17d",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"Diplomatic Area-block 317",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/15/85932215.geojson
+++ b/data/859/322/15/85932215.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":991481
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2480bfabf6b9ad6c8cb32b70b7feaa2",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"East Riffa-block 901",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/17/85932217.geojson
+++ b/data/859/322/17/85932217.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1295835
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"83f8f9233cbe8795c459225297c454ca",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 346",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/21/85932221.geojson
+++ b/data/859/322/21/85932221.geojson
@@ -62,6 +62,10 @@
         "qs_pg:id":406178
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8d274570559c5d8b9fec6be4a8721764",
     "wof:hierarchy":[
         {
@@ -76,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"Budaiya-block 559",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/31/85932231.geojson
+++ b/data/859/322/31/85932231.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":242172
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0926d5685790c302d16aa13f89644a32",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"Qudaibiya-block 325",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/35/85932235.geojson
+++ b/data/859/322/35/85932235.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":44282
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a098418cae226c87cfc620e882387c7",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"Mogabah-block 505",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/39/85932239.geojson
+++ b/data/859/322/39/85932239.geojson
@@ -62,6 +62,10 @@
         "qs_pg:id":996313
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2def32d0bc986aa183a53fc6b58bdd8",
     "wof:hierarchy":[
         {
@@ -76,7 +80,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"Halat Naim-block 248",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/45/85932245.geojson
+++ b/data/859/322/45/85932245.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":523517
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6750a3a6611ad87b219f7e0ea8a85ae7",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"Maameer-block 635",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/49/85932249.geojson
+++ b/data/859/322/49/85932249.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":991482
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a4d21c94c11eb72d022b1e82443ceca1",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614338,
+    "wof:lastmodified":1582345712,
     "wof:name":"Rowdha-block 1210",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/53/85932253.geojson
+++ b/data/859/322/53/85932253.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":991483
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c24847e297e0cc220480533f717efc50",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"West Riffa-block 922",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/55/85932255.geojson
+++ b/data/859/322/55/85932255.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":991484
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3458ecb9739dff72be965092f7bfbfed",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"Malkiya-block 1033",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/59/85932259.geojson
+++ b/data/859/322/59/85932259.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1247487
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"64b1199181ff729f403bae13a0f8b4de",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345712,
     "wof:name":"Qalaa-block 438",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/65/85932265.geojson
+++ b/data/859/322/65/85932265.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":888409
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b96b4f8a68cb5ab5f2fce02775ab9e2",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 324",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/69/85932269.geojson
+++ b/data/859/322/69/85932269.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":888416
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9a4f1cc2f73a43d1e01ddb89f72e2bb1",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 315",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/73/85932273.geojson
+++ b/data/859/322/73/85932273.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":212599
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"158229a7e0c3e48cbe002f5783cbf48c",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 351",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/77/85932277.geojson
+++ b/data/859/322/77/85932277.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":212600
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1afdfdafd6d851a0914b14718eb8c240",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 304",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/83/85932283.geojson
+++ b/data/859/322/83/85932283.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":888417
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8367af076769a023e09a9cbc34d1982c",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"Muharraq City-block 211",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/87/85932287.geojson
+++ b/data/859/322/87/85932287.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":212601
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"71f717a0146c7b0da3363b2c6890175f",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566614336,
+    "wof:lastmodified":1582345712,
     "wof:name":"\u0645\u062c\u0645\u0639 316",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/91/85932291.geojson
+++ b/data/859/322/91/85932291.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295843
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9196e190e15db3ba59fb02b745d41c8c",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614337,
+    "wof:lastmodified":1582345712,
     "wof:name":"A'ali-block 742",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/322/95/85932295.geojson
+++ b/data/859/322/95/85932295.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":991485
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b76f7964a86bcd3662d4ccb3e9759093",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345712,
     "wof:name":"Muharraq City-block 224",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/01/85932301.geojson
+++ b/data/859/323/01/85932301.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":128085
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f04dffd6c227bc83da6fecc62c353dd6",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345712,
     "wof:name":"Rowdha-block 1209",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/05/85932305.geojson
+++ b/data/859/323/05/85932305.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":1295837
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b35d8aff0ab73e71e64be7828f3ef32",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345712,
     "wof:name":"Galali-block 255",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/323/09/85932309.geojson
+++ b/data/859/323/09/85932309.geojson
@@ -66,6 +66,10 @@
         "qs_pg:id":128088
     },
     "wof:country":"BH",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"42dff09ffa0bcd07a053f39d1c7fdcc3",
     "wof:hierarchy":[
         {
@@ -80,7 +84,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566614335,
+    "wof:lastmodified":1582345712,
     "wof:name":"Askar-block 950",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.