### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/174/617/421174617.geojson
+++ b/data/421/174/617/421174617.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421174617,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423088,
     "wof:name":"Block 301",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/174/617/421174617.geojson
+++ b/data/421/174/617/421174617.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062c\u0645\u0639 301"
+    ],
+    "name:eng_x_preferred":[
+        "Block 301"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421174617,
-    "wof:lastmodified":1566614348,
-    "wof:name":"\u0645\u062c\u0645\u0639 301",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Block 301",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/179/677/421179677.geojson
+++ b/data/421/179/677/421179677.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0648\u0627\u0644\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Awali"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421179677,
-    "wof:lastmodified":1566614351,
-    "wof:name":"\u0639\u0648\u0627\u0644\u064a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Awali",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/179/677/421179677.geojson
+++ b/data/421/179/677/421179677.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421179677,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423087,
     "wof:name":"Awali",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",

--- a/data/421/184/983/421184983.geojson
+++ b/data/421/184/983/421184983.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062c\u0646\u0648\u0633\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Jannusan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184983,
-    "wof:lastmodified":1566614351,
-    "wof:name":"\u062c\u0646\u0648\u0633\u0627\u0646",
+    "wof:lastmodified":1601068395,
+    "wof:name":"Jannusan",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/184/983/421184983.geojson
+++ b/data/421/184/983/421184983.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.4985805,26.2326085,50.4985805,26.2326085",
+    "geom:bbox":"50.498581,26.232609,50.498581,26.232609",
     "geom:latitude":26.232609,
     "geom:longitude":50.498581,
     "iso:country":"BH",
@@ -54,7 +54,7 @@
     },
     "wof:country":"BH",
     "wof:created":1459009428,
-    "wof:geomhash":"62f1a184c9f9bf8d6bf4631724c8bc3b",
+    "wof:geomhash":"4347475889321f81667153fdf456f96a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184983,
-    "wof:lastmodified":1601068395,
+    "wof:lastmodified":1601423089,
     "wof:name":"Jannusan",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    50.4985805,
-    26.2326085,
-    50.4985805,
-    26.2326085
+    50.498581,
+    26.232609,
+    50.498581,
+    26.232609
 ],
-  "geometry": {"coordinates":[50.4985805,26.2326085],"type":"Point"}
+  "geometry": {"coordinates":[50.498581,26.232609],"type":"Point"}
 }

--- a/data/421/185/289/421185289.geojson
+++ b/data/421/185/289/421185289.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421185289,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423088,
     "wof:name":"Block 306",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/185/289/421185289.geojson
+++ b/data/421/185/289/421185289.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062c\u0645\u0639 306"
+    ],
+    "name:eng_x_preferred":[
+        "Block 306"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421185289,
-    "wof:lastmodified":1566614352,
-    "wof:name":"\u0645\u062c\u0645\u0639 306",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Block 306",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/186/255/421186255.geojson
+++ b/data/421/186/255/421186255.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0644\u0645\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Salmaniya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421186255,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u0633\u0644\u0645\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Salmaniya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/186/255/421186255.geojson
+++ b/data/421/186/255/421186255.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421186255,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Salmaniya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/186/895/421186895.geojson
+++ b/data/421/186/895/421186895.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421186895,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Karzakan",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/186/895/421186895.geojson
+++ b/data/421/186/895/421186895.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0631\u0632\u0643\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Karzakan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421186895,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0643\u0631\u0632\u0643\u0627\u0646",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Karzakan",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/187/737/421187737.geojson
+++ b/data/421/187/737/421187737.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421187737,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Ras Rumman",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/187/737/421187737.geojson
+++ b/data/421/187/737/421187737.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0627\u0633 \u0631\u0645\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Rumman"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421187737,
-    "wof:lastmodified":1566614348,
-    "wof:name":"\u0631\u0627\u0633 \u0631\u0645\u0627\u0646",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Ras Rumman",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/188/353/421188353.geojson
+++ b/data/421/188/353/421188353.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649"
+    ],
+    "name:eng_x_preferred":[
+        "Isa Town"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421188353,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Isa Town",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/188/353/421188353.geojson
+++ b/data/421/188/353/421188353.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":26.169612,
     "geom:longitude":50.556968,
     "iso:country":"BH",
-    "label:eng_x_preferred_longname":[
-        "Isa Town"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "town"
-    ],
     "lbl:bbox":"50.536968,26.149612,50.576968,26.189612",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -27,9 +21,6 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649"
     ],
     "name:eng_x_preferred":[
-        "Isa"
-    ],
-    "name:eng_x_variant":[
         "Isa Town"
     ],
     "qs:gn_country":null,
@@ -73,8 +64,8 @@
         }
     ],
     "wof:id":421188353,
-    "wof:lastmodified":1601337573,
-    "wof:name":"Isa",
+    "wof:lastmodified":1601423089,
+    "wof:name":"Isa Town",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/188/353/421188353.geojson
+++ b/data/421/188/353/421188353.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":26.169612,
     "geom:longitude":50.556968,
     "iso:country":"BH",
+    "label:eng_x_preferred_longname":[
+        "Isa Town"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "town"
+    ],
     "lbl:bbox":"50.536968,26.149612,50.576968,26.189612",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649"
     ],
     "name:eng_x_preferred":[
+        "Isa"
+    ],
+    "name:eng_x_variant":[
         "Isa Town"
     ],
     "qs:gn_country":null,
@@ -64,8 +73,8 @@
         }
     ],
     "wof:id":421188353,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Isa Town",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Isa",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/623/421190623.geojson
+++ b/data/421/190/623/421190623.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190623,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jasra",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/623/421190623.geojson
+++ b/data/421/190/623/421190623.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0633\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jasra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190623,
-    "wof:lastmodified":1566614350,
-    "wof:name":"\u0627\u0644\u062c\u0633\u0631\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jasra",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/629/421190629.geojson
+++ b/data/421/190/629/421190629.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062f\u0631\u0627\u0632"
+    ],
+    "name:eng_x_preferred":[
+        "Al Diraz"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190629,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u062f\u0631\u0627\u0632",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Diraz",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/629/421190629.geojson
+++ b/data/421/190/629/421190629.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190629,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Diraz",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/633/421190633.geojson
+++ b/data/421/190/633/421190633.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u062f\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Adliyyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190633,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u0639\u062f\u0644\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Adliyyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/633/421190633.geojson
+++ b/data/421/190/633/421190633.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.5853455,26.2156305,50.5853455,26.2156305",
+    "geom:bbox":"50.585346,26.21563,50.585346,26.21563",
     "geom:latitude":26.21563,
     "geom:longitude":50.585346,
     "iso:country":"BH",
@@ -53,7 +53,7 @@
     },
     "wof:country":"BH",
     "wof:created":1459009664,
-    "wof:geomhash":"47dbebf7775e3ea9fc19f1252535163f",
+    "wof:geomhash":"0de49affa6876fc72ee37512bb94f114",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190633,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Adliyyah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    50.5853455,
-    26.2156305,
-    50.5853455,
-    26.2156305
+    50.585346,
+    26.21563,
+    50.585346,
+    26.21563
 ],
-  "geometry": {"coordinates":[50.5853455,26.2156305],"type":"Point"}
+  "geometry": {"coordinates":[50.585346,26.21563],"type":"Point"}
 }

--- a/data/421/190/635/421190635.geojson
+++ b/data/421/190/635/421190635.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0647\u0645\u0644\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hamla"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190635,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u0647\u0645\u0644\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Hamla",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/635/421190635.geojson
+++ b/data/421/190/635/421190635.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190635,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hamla",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/637/421190637.geojson
+++ b/data/421/190/637/421190637.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190637,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423092,
     "wof:name":"Riffa East",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",

--- a/data/421/190/637/421190637.geojson
+++ b/data/421/190/637/421190637.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0641\u0627\u0639 \u0627\u0644\u0634\u0631\u0642\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Riffa East"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190637,
-    "wof:lastmodified":1566614350,
-    "wof:name":"\u0627\u0644\u0631\u0641\u0627\u0639 \u0627\u0644\u0634\u0631\u0642\u064a",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Riffa East",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/639/421190639.geojson
+++ b/data/421/190/639/421190639.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0627\u0644\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "A'ali"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -65,8 +71,8 @@
         }
     ],
     "wof:id":421190639,
-    "wof:lastmodified":1566614350,
-    "wof:name":"\u0639\u0627\u0644\u064a",
+    "wof:lastmodified":1601068398,
+    "wof:name":"A'ali",
     "wof:parent_id":-4,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/639/421190639.geojson
+++ b/data/421/190/639/421190639.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":421190639,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423082,
     "wof:name":"A'ali",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/421/190/641/421190641.geojson
+++ b/data/421/190/641/421190641.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0633\u0643\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Askar"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190641,
-    "wof:lastmodified":1566614350,
-    "wof:name":"\u0639\u0633\u0643\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Askar",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/641/421190641.geojson
+++ b/data/421/190/641/421190641.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.615386,26.0577845,50.615386,26.0577845",
+    "geom:bbox":"50.615386,26.057785,50.615386,26.057785",
     "geom:latitude":26.057785,
     "geom:longitude":50.615386,
     "iso:country":"BH",
@@ -54,7 +54,7 @@
     },
     "wof:country":"BH",
     "wof:created":1459009664,
-    "wof:geomhash":"83e7bc902c47898278eeb6973319eabd",
+    "wof:geomhash":"0bad9720543d57b7a83e6ad213a7aa45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190641,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423087,
     "wof:name":"Askar",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
@@ -75,9 +75,9 @@
 },
   "bbox": [
     50.615386,
-    26.0577845,
+    26.057785,
     50.615386,
-    26.0577845
+    26.057785
 ],
-  "geometry": {"coordinates":[50.615386,26.0577845],"type":"Point"}
+  "geometry": {"coordinates":[50.615386,26.057785],"type":"Point"}
 }

--- a/data/421/190/643/421190643.geojson
+++ b/data/421/190/643/421190643.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0627\u0644\u0643\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Malikiya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190643,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u0645\u0627\u0644\u0643\u064a\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Malikiya",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/643/421190643.geojson
+++ b/data/421/190/643/421190643.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190643,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Malikiya",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/645/421190645.geojson
+++ b/data/421/190/645/421190645.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"50.5400215,26.1090965,50.5400215,26.1090965",
+    "geom:bbox":"50.540022,26.109096,50.540022,26.109096",
     "geom:latitude":26.109096,
     "geom:longitude":50.540022,
     "iso:country":"BH",
@@ -54,7 +54,7 @@
     },
     "wof:country":"BH",
     "wof:created":1459009664,
-    "wof:geomhash":"8fb4ede9b3b4ba0e8b9afe5ed47ca305",
+    "wof:geomhash":"e2fd626e5e0910a83a3f4a4311aa28fe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190645,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423092,
     "wof:name":"Riffa West",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
@@ -74,10 +74,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    50.5400215,
-    26.1090965,
-    50.5400215,
-    26.1090965
+    50.540022,
+    26.109096,
+    50.540022,
+    26.109096
 ],
-  "geometry": {"coordinates":[50.5400215,26.1090965],"type":"Point"}
+  "geometry": {"coordinates":[50.540022,26.109096],"type":"Point"}
 }

--- a/data/421/190/645/421190645.geojson
+++ b/data/421/190/645/421190645.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0641\u0627\u0639 \u0627\u0644\u063a\u0631\u0628\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Riffa West"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190645,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0627\u0644\u0631\u0641\u0627\u0639 \u0627\u0644\u063a\u0631\u0628\u064a",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Riffa West",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/651/421190651.geojson
+++ b/data/421/190/651/421190651.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190651,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sanad",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",

--- a/data/421/190/651/421190651.geojson
+++ b/data/421/190/651/421190651.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0646\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Sanad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190651,
-    "wof:lastmodified":1566614349,
-    "wof:name":"\u0633\u0646\u062f",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sanad",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/190/653/421190653.geojson
+++ b/data/421/190/653/421190653.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190653,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Salmabad",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/653/421190653.geojson
+++ b/data/421/190/653/421190653.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0644\u0645\u0627\u0628\u0627\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Salmabad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190653,
-    "wof:lastmodified":1566614350,
-    "wof:name":"\u0633\u0644\u0645\u0627\u0628\u0627\u062f",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Salmabad",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/197/113/421197113.geojson
+++ b/data/421/197/113/421197113.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421197113,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423088,
     "wof:name":"Block 308",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/197/113/421197113.geojson
+++ b/data/421/197/113/421197113.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062c\u0645\u0639 308"
+    ],
+    "name:eng_x_preferred":[
+        "Block 308"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421197113,
-    "wof:lastmodified":1566614351,
-    "wof:name":"\u0645\u062c\u0645\u0639 308",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Block 308",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-bh",

--- a/data/421/197/145/421197145.geojson
+++ b/data/421/197/145/421197145.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":421197145,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Zallaq",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/421/197/145/421197145.geojson
+++ b/data/421/197/145/421197145.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0632\u0644\u0627\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Zallaq"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -65,8 +71,8 @@
         }
     ],
     "wof:id":421197145,
-    "wof:lastmodified":1566614351,
-    "wof:name":"\u0627\u0644\u0632\u0644\u0627\u0642",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Zallaq",
     "wof:parent_id":-4,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-bh",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.