### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/581/910/7/1125819107.geojson
+++ b/data/112/581/910/7/1125819107.geojson
@@ -28,14 +28,26 @@
     "name:ara_x_variant":[
         "\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0639\u064a\u0633\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Isa Town"
+    ],
     "name:aze_x_preferred":[
         "Madinat-\u0130sa"
+    ],
+    "name:ben_x_preferred":[
+        "\u0988\u09b8\u09be \u09b6\u09b9\u09b0"
     ],
     "name:ceb_x_preferred":[
         "Mad\u012bnat \u2018\u012as\u00e1"
     ],
     "name:deu_x_preferred":[
         "Madinat Isa"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b1\u03bd\u03c4\u03af\u03bd\u03b1\u03c4 \u038a\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "Isa Town"
@@ -68,6 +80,9 @@
         "Isa Town"
     ],
     "name:nno_x_preferred":[
+        "Isa by"
+    ],
+    "name:nob_x_preferred":[
         "Isa by"
     ],
     "name:pol_x_preferred":[
@@ -146,7 +161,7 @@
         }
     ],
     "wof:id":1125819107,
-    "wof:lastmodified":1566614352,
+    "wof:lastmodified":1690857384,
     "wof:name":"Mad\u012bnat \u2018\u012as\u00e1",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",

--- a/data/112/581/911/9/1125819119.geojson
+++ b/data/112/581/911/9/1125819119.geojson
@@ -27,10 +27,20 @@
     ],
     "name:ara_x_variant":[
         "\u0645\u062d\u0631\u0642",
+        "\u0627\u0644\u0645\u062d\u0631\u0642",
+        "\u0627\u0644\u0628\u062d\u0631\u064a\u0646"
+    ],
+    "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u062d\u0631\u0642"
+    ],
+    "name:ast_x_preferred":[
+        "Al-Muharraq"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09c1\u09b9\u09be\u09b0\u09b0\u09be\u0995"
+    ],
+    "name:ben_x_variant":[
+        "\u09ae\u09c1\u09b9\u09be\u09b0\u09b0\u09be\u0995 \u09b6\u09b9\u09b0"
     ],
     "name:cat_x_preferred":[
         "Al-Muharraq"
@@ -50,11 +60,15 @@
     "name:ell_x_preferred":[
         "\u039c\u03bf\u03c5\u03c7\u03b1\u03c1\u03ac\u03ba"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03bf\u03c5\u03c7\u03ac\u03c1\u03b1\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Al Muharraq"
     ],
     "name:eng_x_variant":[
-        "Muharraq"
+        "Muharraq",
+        "Al-Muharraq"
     ],
     "name:epo_x_preferred":[
         "Muharrako"
@@ -219,7 +233,7 @@
         }
     ],
     "wof:id":1125819119,
-    "wof:lastmodified":1566614352,
+    "wof:lastmodified":1690857384,
     "wof:name":"Al Mu\u1e29arraq",
     "wof:parent_id":85669059,
     "wof:placetype":"locality",

--- a/data/421/174/137/421174137.geojson
+++ b/data/421/174/137/421174137.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_variant":[
         "\u062f\u0627\u0631 \u0643\u0644\u064a\u0628"
     ],
+    "name:ben_x_preferred":[
+        "\u09a6\u09be\u09b0 \u0995\u09c1\u09b2\u09be\u0987\u09ac"
+    ],
     "name:ceb_x_preferred":[
         "D\u0101r Kulayb"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421174137,
-    "wof:lastmodified":1566614348,
+    "wof:lastmodified":1690857383,
     "wof:name":"\u062f\u0627\u0631 \u0643\u0644\u064a\u0628",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/190/647/421190647.geojson
+++ b/data/421/190/647/421190647.geojson
@@ -47,6 +47,9 @@
     "name:arg_x_preferred":[
         "Manama"
     ],
+    "name:ary_x_preferred":[
+        "\u0645\u0646\u0627\u0645\u0629"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0644\u0645\u0646\u0627\u0645\u0647"
     ],
@@ -62,11 +65,17 @@
     "name:bak_x_preferred":[
         "\u041c\u0430\u043d\u0430\u043c\u0430"
     ],
+    "name:ban_x_preferred":[
+        "Manama"
+    ],
     "name:bcl_x_preferred":[
         "Manama"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041c\u0430\u043d\u0430\u043c\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u041c\u0430\u043d\u0430\u043c\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09a8\u09be\u09ae\u09be"
@@ -164,6 +173,9 @@
     "name:hat_x_preferred":[
         "Manama"
     ],
+    "name:hau_x_preferred":[
+        "Manama"
+    ],
     "name:hbs_x_preferred":[
         "Manama"
     ],
@@ -248,6 +260,9 @@
     "name:lav_x_preferred":[
         "Man\u0101ma"
     ],
+    "name:lij_x_preferred":[
+        "Manama"
+    ],
     "name:lit_x_preferred":[
         "Manama"
     ],
@@ -284,8 +299,14 @@
     "name:msa_x_preferred":[
         "Manama"
     ],
+    "name:mya_x_preferred":[
+        "\u1019\u102c\u1014\u102c\u1019\u102c\u1019\u103c\u102d\u102f\u1037"
+    ],
     "name:myv_x_preferred":[
         "\u041c\u0430\u043d\u0430\u043c\u0430"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0646\u0627\u0645\u0647"
     ],
     "name:nah_x_preferred":[
         "Manamah"
@@ -304,6 +325,9 @@
     ],
     "name:nld_x_preferred":[
         "Manamah"
+    ],
+    "name:nld_x_variant":[
+        "Manama"
     ],
     "name:nno_x_preferred":[
         "Manama"
@@ -380,6 +404,15 @@
     "name:slv_x_preferred":[
         "Manama"
     ],
+    "name:sme_x_preferred":[
+        "Manama"
+    ],
+    "name:smn_x_preferred":[
+        "Manama"
+    ],
+    "name:sms_x_preferred":[
+        "Manama"
+    ],
     "name:sna_x_preferred":[
         "Manama"
     ],
@@ -387,6 +420,9 @@
         "Manama"
     ],
     "name:sqi_x_preferred":[
+        "Manama"
+    ],
+    "name:srd_x_preferred":[
         "Manama"
     ],
     "name:srp_x_preferred":[
@@ -422,6 +458,9 @@
     "name:tur_x_preferred":[
         "Manama"
     ],
+    "name:udm_x_preferred":[
+        "\u041c\u0430\u043d\u0430\u043c\u0430"
+    ],
     "name:ukr_x_preferred":[
         "\u041c\u0430\u043d\u0430\u043c\u0430"
     ],
@@ -432,6 +471,9 @@
         "\u0645\u0646\u0627\u0645\u06c1"
     ],
     "name:uzb_x_preferred":[
+        "Manama"
+    ],
+    "name:vec_x_preferred":[
         "Manama"
     ],
     "name:vep_x_preferred":[
@@ -614,7 +656,7 @@
         }
     ],
     "wof:id":421190647,
-    "wof:lastmodified":1607390892,
+    "wof:lastmodified":1690857384,
     "wof:name":"Manama",
     "wof:parent_id":85669053,
     "wof:placetype":"locality",

--- a/data/421/192/447/421192447.geojson
+++ b/data/421/192/447/421192447.geojson
@@ -23,11 +23,26 @@
     "name:ara_x_variant":[
         "\u0645\u062f\u064a\u0646\u0629 \u062d\u0645\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u062d\u0645\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Hamad Town"
+    ],
     "name:aze_x_preferred":[
         "H\u0259m\u0259d"
     ],
+    "name:ben_x_preferred":[
+        "\u09b9\u09be\u09ae\u09be\u09a6 \u09b6\u09b9\u09b0"
+    ],
     "name:ceb_x_preferred":[
         "Mad\u012bnat \u1e28amad"
+    ],
+    "name:dan_x_preferred":[
+        "Mad\u012bnat \u1e28amad"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03b1\u03bd\u03c4\u03af\u03bd\u03b1\u03c4 \u03a7\u03b1\u03bc\u03ac\u03bd\u03c4"
     ],
     "name:eng_x_preferred":[
         "Hamad Town"
@@ -60,6 +75,9 @@
         "Madinat Hamad"
     ],
     "name:nno_x_preferred":[
+        "Hamad by"
+    ],
+    "name:nob_x_preferred":[
         "Hamad by"
     ],
     "name:pol_x_preferred":[
@@ -137,7 +155,7 @@
         }
     ],
     "wof:id":421192447,
-    "wof:lastmodified":1566614347,
+    "wof:lastmodified":1690857383,
     "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u062d\u0645\u062f",
     "wof:parent_id":85669043,
     "wof:placetype":"locality",

--- a/data/421/192/451/421192451.geojson
+++ b/data/421/192/451/421192451.geojson
@@ -27,11 +27,20 @@
     "name:arz_x_preferred":[
         "\u0627\u0644\u0631\u0641\u0627\u0639"
     ],
+    "name:ast_x_preferred":[
+        "Riffa"
+    ],
+    "name:aze_x_preferred":[
+        "\u018fr-Rifa"
+    ],
     "name:bel_x_preferred":[
         "\u0420\u044b\u0444\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09b0\u09bf\u09ab\u09be"
+    ],
+    "name:cat_x_preferred":[
+        "Riffa"
     ],
     "name:ceb_x_preferred":[
         "Ar Rif\u0101\u2018"
@@ -45,10 +54,19 @@
     "name:dan_x_preferred":[
         "Riffa"
     ],
+    "name:deu_x_preferred":[
+        "Riffa"
+    ],
     "name:ell_x_preferred":[
         "\u03a1\u03af\u03c6\u03b1"
     ],
+    "name:ell_x_variant":[
+        "\u03a1\u03b9\u03c6\u03ac"
+    ],
     "name:eng_x_preferred":[
+        "Riffa"
+    ],
+    "name:epo_x_preferred":[
         "Riffa"
     ],
     "name:est_x_preferred":[
@@ -64,6 +82,9 @@
         "Al-Riffa"
     ],
     "name:fra_x_preferred":[
+        "Riffa"
+    ],
+    "name:gle_x_preferred":[
         "Riffa"
     ],
     "name:guj_x_preferred":[
@@ -168,6 +189,9 @@
     "name:urd_x_preferred":[
         "\u0631\u0641\u0627\u0639"
     ],
+    "name:vec_x_preferred":[
+        "Riffa"
+    ],
     "name:vie_x_preferred":[
         "Riffa"
     ],
@@ -219,7 +243,7 @@
         }
     ],
     "wof:id":421192451,
-    "wof:lastmodified":1566614347,
+    "wof:lastmodified":1690857383,
     "wof:name":"Ar Rifa",
     "wof:parent_id":85669039,
     "wof:placetype":"locality",

--- a/data/421/194/055/421194055.geojson
+++ b/data/421/194/055/421194055.geojson
@@ -32,6 +32,9 @@
     "name:deu_x_preferred":[
         "Dschidhafs"
     ],
+    "name:ell_x_preferred":[
+        "\u0396\u03b9\u03bd\u03c4\u03ac\u03c6\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Jidhafs"
     ],
@@ -79,6 +82,9 @@
     ],
     "name:tgl_x_preferred":[
         "Jidd Haffs"
+    ],
+    "name:tur_x_preferred":[
+        "Jidhafs"
     ],
     "name:und_x_variant":[
         "Judd \u1e28af\u015f"
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":421194055,
-    "wof:lastmodified":1566614347,
+    "wof:lastmodified":1690857383,
     "wof:name":"\u062c\u062f \u062d\u0641\u0635",
     "wof:parent_id":85669053,
     "wof:placetype":"locality",

--- a/data/856/321/67/85632167.geojson
+++ b/data/856/321/67/85632167.geojson
@@ -27,6 +27,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0411\u0430\u04b3\u0440\u0435\u0438\u043d"
+    ],
     "name:ace_x_preferred":[
         "Bahrain"
     ],
@@ -39,6 +42,9 @@
     "name:aka_x_preferred":[
         "Baren"
     ],
+    "name:aka_x_variant":[
+        "Bahrain"
+    ],
     "name:als_x_preferred":[
         "Bahrain"
     ],
@@ -48,8 +54,14 @@
     "name:amh_x_variant":[
         "\u1263\u1205\u122c\u1295"
     ],
+    "name:ami_x_preferred":[
+        "Bahrain"
+    ],
     "name:ang_x_preferred":[
         "Bahrain"
+    ],
+    "name:anp_x_preferred":[
+        "\u092c\u0939\u0930\u0940\u0928"
     ],
     "name:ara_x_preferred":[
         "\u0627\u0644\u0628\u062d\u0631\u064a\u0646"
@@ -81,6 +93,9 @@
         "Bahrein",
         "Ba\u1e25r\u00e9in"
     ],
+    "name:awa_x_preferred":[
+        "\u092c\u0939\u0930\u093e\u0907\u0928"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u062d\u0631\u0626\u06cc\u0646"
     ],
@@ -98,6 +113,9 @@
     ],
     "name:bam_x_preferred":[
         "Bareyini"
+    ],
+    "name:ban_x_preferred":[
+        "Bahrain"
     ],
     "name:bar_x_preferred":[
         "Bahrain"
@@ -183,6 +201,9 @@
     "name:cor_x_preferred":[
         "Bahreyn"
     ],
+    "name:cos_x_preferred":[
+        "Bareine"
+    ],
     "name:crh_x_preferred":[
         "Bahreyn"
     ],
@@ -190,6 +211,9 @@
         "Bahrajn"
     ],
     "name:cym_x_preferred":[
+        "Bahrain"
+    ],
+    "name:dag_x_preferred":[
         "Bahrain"
     ],
     "name:dan_x_preferred":[
@@ -319,6 +343,12 @@
     ],
     "name:gom_x_preferred":[
         "\u092c\u0939\u0930\u0948\u0928"
+    ],
+    "name:gor_x_preferred":[
+        "Bahrain"
+    ],
+    "name:gpe_x_preferred":[
+        "Bahrain"
     ],
     "name:grn_x_preferred":[
         "Var\u00e9\u0129"
@@ -525,6 +555,9 @@
     "name:lit_x_preferred":[
         "Bahreinas"
     ],
+    "name:lld_x_preferred":[
+        "Bahrain"
+    ],
     "name:lmo_x_preferred":[
         "Bahrain"
     ],
@@ -546,6 +579,9 @@
     "name:lzh_x_preferred":[
         "\u5df4\u6797"
     ],
+    "name:mad_x_preferred":[
+        "Bahrain"
+    ],
     "name:mai_x_preferred":[
         "\u092c\u0939\u093e\u0930\u093e\u0907\u0928"
     ],
@@ -560,6 +596,12 @@
     ],
     "name:mar_x_variant":[
         "\u092c\u0939\u093e\u0930\u0940\u0928"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0411\u0430\u0445\u0440\u044d\u0439\u043d"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0411\u0430\u0445\u0440\u0435\u0439\u043d"
     ],
     "name:min_x_preferred":[
         "Bahrain"
@@ -580,13 +622,23 @@
         "Ba\u0127rejn"
     ],
     "name:mlt_x_variant":[
-        "Ba\u0127rajn"
+        "Ba\u0127rajn",
+        "Bahrain"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd5\uabe5\uabcd\uabd4\uabe6\uabdf"
     ],
     "name:mon_x_preferred":[
         "\u0411\u0430\u0445\u0440\u0435\u0439\u043d"
     ],
+    "name:mri_x_preferred":[
+        "P\u0101reina"
+    ],
     "name:msa_x_preferred":[
         "Bahrain"
+    ],
+    "name:mwl_x_preferred":[
+        "Bahrein"
     ],
     "name:mya_x_preferred":[
         "\u1018\u102c\u101b\u102d\u1014\u103a\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
@@ -753,6 +805,9 @@
     "name:sgs_x_preferred":[
         "Bahreins"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1015\u1083\u1087\u101b\u1035\u107c\u103a\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0db6\u0dc4\u0dbb\u0dda\u0db1\u0dca"
     ],
@@ -765,8 +820,14 @@
     "name:sme_x_preferred":[
         "Bahrain"
     ],
+    "name:smn_x_preferred":[
+        "Bahrain"
+    ],
     "name:smo_x_preferred":[
         "Bahrain"
+    ],
+    "name:sms_x_preferred":[
+        "Bahrainn"
     ],
     "name:sna_x_preferred":[
         "Bahrain"
@@ -839,6 +900,9 @@
     "name:tat_x_preferred":[
         "\u0411\u04d9\u0445\u0440\u04d9\u0439\u043d"
     ],
+    "name:tay_x_preferred":[
+        "Bahrain"
+    ],
     "name:tel_x_preferred":[
         "\u0c2c\u0c39\u0c4d\u0c30\u0c2f\u0c3f\u0c28\u0c4d"
     ],
@@ -866,10 +930,16 @@
     "name:tir_x_preferred":[
         "\u1263\u1205\u122c\u1295"
     ],
+    "name:tok_x_preferred":[
+        "ma Palani"
+    ],
     "name:ton_x_preferred":[
         "Paleini"
     ],
     "name:tpi_x_preferred":[
+        "Bahrain"
+    ],
+    "name:trv_x_preferred":[
         "Bahrain"
     ],
     "name:tso_x_preferred":[
@@ -1185,7 +1255,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1617827488,
+    "wof:lastmodified":1690857382,
     "wof:name":"Bahrain",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/690/39/85669039.geojson
+++ b/data/856/690/39/85669039.geojson
@@ -36,6 +36,9 @@
         "Al Jan\u016bb\u012byah",
         "\u062c\u0646\u0648\u0628\u064a\u0629"
     ],
+    "name:aze_x_preferred":[
+        "C\u0259nub qubernatorlu\u011fu"
+    ],
     "name:bul_x_preferred":[
         "\u042e\u0436\u043d\u0430 \u043f\u0440\u043e\u0432\u0438\u043d\u0446\u0438\u044f"
     ],
@@ -44,6 +47,12 @@
     ],
     "name:ceb_x_preferred":[
         "Southern Governorate"
+    ],
+    "name:dan_x_preferred":[
+        "Sydlige Guvernement"
+    ],
+    "name:deu_x_preferred":[
+        "S\u00fcdliches Gouvernement"
     ],
     "name:eng_x_preferred":[
         "Southern"
@@ -67,6 +76,9 @@
     ],
     "name:fra_x_preferred":[
         "Gouvernorat m\u00e9ridional"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d4\u05d3\u05e8\u05d5\u05dd"
     ],
     "name:hun_x_preferred":[
         "D\u00e9li korm\u00e1nyz\u00f3s\u00e1g"
@@ -95,6 +107,9 @@
     "name:nld_x_preferred":[
         "Zuid"
     ],
+    "name:nld_x_variant":[
+        "Zuidelijk gouvernement"
+    ],
     "name:nob_x_preferred":[
         "S\u00f8rlige guvernement"
     ],
@@ -121,6 +136,12 @@
     ],
     "name:swe_x_preferred":[
         "Southern Governorate"
+    ],
+    "name:tam_x_preferred":[
+        "\u0ba4\u0bc6\u0bb1\u0bcd\u0b95\u0bc1 \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u041a\u04e9\u043d\u044c\u044f\u043a \u043c\u0443\u0445\u0430\u0444\u0430\u0437\u0430"
     ],
     "name:tur_x_preferred":[
         "G\u00fcney Valili\u011fi"
@@ -268,7 +289,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636500647,
+    "wof:lastmodified":1690857382,
     "wof:name":"Southern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/43/85669043.geojson
+++ b/data/856/690/43/85669043.geojson
@@ -48,6 +48,12 @@
     "name:deu_x_preferred":[
         "Schamal"
     ],
+    "name:deu_x_variant":[
+        "N\u00f6rdliches Gouvernement"
+    ],
+    "name:ell_x_preferred":[
+        "\u0392\u03cc\u03c1\u03b5\u03b9\u03bf \u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf"
+    ],
     "name:eng_x_colloquial":[
         "Northern"
     ],
@@ -62,6 +68,9 @@
     "name:epo_x_preferred":[
         "Norda Provinco"
     ],
+    "name:epo_x_variant":[
+        "Norda gubernio"
+    ],
     "name:eus_x_preferred":[
         "Iparraldeko eskualdea"
     ],
@@ -70,6 +79,9 @@
     ],
     "name:fra_x_preferred":[
         "Gouvernorat septentrional"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d4\u05e6\u05e4\u05d5\u05df"
     ],
     "name:hun_x_preferred":[
         "\u00c9szaki"
@@ -136,6 +148,12 @@
     ],
     "name:swe_x_variant":[
         "Northern Governorate"
+    ],
+    "name:tam_x_preferred":[
+        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u0422\u04e9\u043d\u044c\u044f\u043a \u043c\u0443\u0445\u0430\u0444\u0430\u0437\u0430"
     ],
     "name:tur_x_preferred":[
         "Kuzey Valili\u011fi"
@@ -273,7 +291,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636500647,
+    "wof:lastmodified":1690857381,
     "wof:name":"Northern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/53/85669053.geojson
+++ b/data/856/690/53/85669053.geojson
@@ -78,6 +78,9 @@
     "name:fra_x_variant":[
         "Gouvernorat de la capitale"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05d4\u05d1\u05d9\u05e8\u05d4"
+    ],
     "name:hun_x_preferred":[
         "F\u0151v\u00e1ros korm\u00e1nyz\u00f3s\u00e1g"
     ],
@@ -107,6 +110,9 @@
     ],
     "name:nld_x_preferred":[
         "Hoofdstad"
+    ],
+    "name:nld_x_variant":[
+        "Hoofdstedelijk gouvernement"
     ],
     "name:nob_x_preferred":[
         "Hovedstadsguvernementet"
@@ -138,8 +144,17 @@
     "name:swe_x_preferred":[
         "Capital Governorate"
     ],
+    "name:tam_x_preferred":[
+        "\u0ba4\u0bb2\u0bc8\u0ba8\u0b95\u0bb0 \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u0411\u0430\u0448\u043a\u0430\u043b\u0430 \u043c\u0443\u0445\u0430\u0444\u0430\u0437\u0430\u0441\u044b"
+    ],
     "name:tgl_x_preferred":[
         "Kabiserang Gobernasyon"
+    ],
+    "name:tur_x_preferred":[
+        "Ba\u015fkent"
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0442\u043e\u043b\u0438\u0447\u043d\u0430 \u043c\u0443\u0445\u0430\u0444\u0430\u0437\u0430"
@@ -279,7 +294,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583882703,
+    "wof:lastmodified":1690857381,
     "wof:name":"Capital",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/59/85669059.geojson
+++ b/data/856/690/59/85669059.geojson
@@ -60,6 +60,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03bf\u03c5\u03c7\u03b1\u03c1\u03ac\u03ba"
     ],
+    "name:ell_x_variant":[
+        "\u039a\u03c5\u03b2\u03b5\u03c1\u03bd\u03b5\u03af\u03bf \u039c\u03bf\u03c5\u03c7\u03ac\u03c1\u03b1\u03ba"
+    ],
     "name:eng_x_preferred":[
         "Muharraq"
     ],
@@ -72,7 +75,8 @@
         "Gubernio Muharrako"
     ],
     "name:epo_x_variant":[
-        "Muharrako provinco"
+        "Muharrako provinco",
+        "gubernio Muharrako"
     ],
     "name:eus_x_preferred":[
         "Muharraq eskualdea"
@@ -88,6 +92,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0aae\u0ac1\u0ab9\u0abe\u0ab0\u0a95 \u0a97\u0ab5\u0ab0\u0acd\u0aa8\u0acb\u0ab0\u0ac7\u0a9f"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d5\u05d7\u05d0\u05e8\u05e7"
     ],
     "name:hin_x_preferred":[
         "\u092e\u0941\u0939\u0930\u0915 \u0917\u0935\u0930\u094d\u0928\u0930\u0947\u091f"
@@ -169,6 +176,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc1\u0bb9\u0bb0\u0bcd\u0bb0\u0b95\u0bcd \u0b95\u0bcb\u0bb5\u0bc6\u0bb0\u0bcd\u0ba9\u0bcb\u0bb0\u0bc7"
+    ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bc1\u0bb9\u0bbe\u0bb0\u0b95\u0bcd \u0b86\u0bb3\u0bc1\u0ba8\u0bb0\u0b95\u0bae\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c2e\u0c41\u0c39\u0c3e\u0c30\u0c4d\u0c30\u0c15\u0c4d \u0c17\u0c35\u0c30\u0c4d\u0c28\u0c30\u0c47\u0c1f\u0c4d"
@@ -313,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583882703,
+    "wof:lastmodified":1690857381,
     "wof:name":"Muharraq",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/859/030/61/85903061.geojson
+++ b/data/859/030/61/85903061.geojson
@@ -44,6 +44,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0644\u063a\u0631\u06cc\u0641\u0647"
     ],
+    "name:nld_x_preferred":[
+        "Ghuraifa"
+    ],
     "qs:gn_adm0_cc":"BH",
     "qs:gn_fcode":"PPLX",
     "qs:gn_local":290340,
@@ -105,7 +108,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582345711,
+    "wof:lastmodified":1690857380,
     "wof:name":"Al Ghurayfah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/67/85903067.geojson
+++ b/data/859/030/67/85903067.geojson
@@ -45,6 +45,9 @@
     "name:fas_x_preferred":[
         "\u0627\u0644\u0645\u0627\u062d\u0648\u0632"
     ],
+    "name:nld_x_preferred":[
+        "Mahooz"
+    ],
     "name:urd_x_preferred":[
         "\u0645\u0627\u062d\u0648\u0632"
     ],
@@ -85,7 +88,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582345711,
+    "wof:lastmodified":1690857380,
     "wof:name":"\u0627\u0644\u0645\u0627\u062d\u0648\u0632",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/73/85903073.geojson
+++ b/data/859/030/73/85903073.geojson
@@ -47,6 +47,9 @@
     "name:fas_x_preferred":[
         "\u0628\u0648\u0639\u0634\u06cc\u0631\u0647"
     ],
+    "name:nld_x_preferred":[
+        "Bu Ashira"
+    ],
     "qs:gn_adm0_cc":"BH",
     "qs:gn_id":0,
     "qs:gn_local":290340,
@@ -105,7 +108,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1582345711,
+    "wof:lastmodified":1690857380,
     "wof:name":"\u0628\u0648 \u0639\u0634\u064a\u0631\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/442/237/890442237.geojson
+++ b/data/890/442/237/890442237.geojson
@@ -25,8 +25,20 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u062d\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u062d\u062f"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09b2-\u09b9\u09bf\u09a6 \u09b6\u09b9\u09b0"
+    ],
     "name:ceb_x_preferred":[
         "Al \u1e28add"
+    ],
+    "name:deu_x_preferred":[
+        "Al-Hidd"
+    ],
+    "name:ell_x_preferred":[
+        "\u0391\u03bb \u03a7\u03b9\u03bd\u03c4"
     ],
     "name:eng_x_preferred":[
         "Al Hidd"
@@ -75,6 +87,9 @@
     ],
     "name:ron_x_preferred":[
         "Al Hadd"
+    ],
+    "name:rus_x_preferred":[
+        "\u042d\u043b\u044c-\u0425\u0438\u0434\u0434"
     ],
     "name:sco_x_preferred":[
         "Al Hadd"
@@ -126,7 +141,7 @@
         }
     ],
     "wof:id":890442237,
-    "wof:lastmodified":1566614352,
+    "wof:lastmodified":1690857384,
     "wof:name":"Al \u1e28add",
     "wof:parent_id":85669059,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.