### PR TITLE
bh concordances, placetype local, and more

### DIFF
--- a/data/856/321/67/85632167.geojson
+++ b/data/856/321/67/85632167.geojson
@@ -1225,6 +1225,7 @@
         "hasc:id":"BH",
         "icao:code":"A9C",
         "ioc:id":"BRN",
+        "iso:code":"BH",
         "itu:id":"BHR",
         "m49:code":"048",
         "marc:id":"ba",
@@ -1238,6 +1239,7 @@
         "wk:page":"Bahrain",
         "wmo:id":"BN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BH",
     "wof:country_alpha3":"BHR",
     "wof:geom_alt":[
@@ -1259,7 +1261,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639529,
+    "wof:lastmodified":1695881186,
     "wof:name":"Bahrain",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/690/39/85669039.geojson
+++ b/data/856/690/39/85669039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044357,
-    "geom:area_square_m":493106745.835086,
+    "geom:area_square_m":493106732.517691,
     "geom:bbox":"50.453122,25.55625,50.82486,26.186784",
     "geom:latitude":25.967073,
     "geom:longitude":50.579514,
@@ -266,15 +266,17 @@
         "gn:id":7090972,
         "gp:id":56051602,
         "hasc:id":"BH.SN",
+        "iso:code":"BH-14",
         "iso:id":"BH-14",
         "qs_pg:id":483132,
         "wd:id":"Q838532"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2fc4cceea76f585f374ff638969dde7a",
+    "wof:geomhash":"1c3653cd00b6bb788e6523e4a8ad7379",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -289,7 +291,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857382,
+    "wof:lastmodified":1695884872,
     "wof:name":"Southern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/43/85669043.geojson
+++ b/data/856/690/43/85669043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01333,
-    "geom:area_square_m":147941562.687692,
+    "geom:area_square_m":147941650.520738,
     "geom:bbox":"50.310047,26.056624,50.540059,26.320621",
     "geom:latitude":26.165473,
     "geom:longitude":50.475713,
@@ -267,16 +267,18 @@
         "gn:id":7090974,
         "gp:id":56051603,
         "hasc:id":"BH.NN",
+        "iso:code":"BH-17",
         "iso:id":"BH-17",
         "qs_pg:id":483133,
         "unlc:id":"BH-17",
         "wd:id":"Q840445"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"430c5c566b15bce9c8d5934ca29b6945",
+    "wof:geomhash":"5fddc01af859fc5c43c7c0cfe8a11954",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857381,
+    "wof:lastmodified":1695884873,
     "wof:name":"Northern",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/53/85669053.geojson
+++ b/data/856/690/53/85669053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006778,
-    "geom:area_square_m":75193975.921455,
+    "geom:area_square_m":75193942.534063,
     "geom:bbox":"50.502317,26.123685,50.632434,26.25863",
     "geom:latitude":26.201601,
     "geom:longitude":50.576626,
@@ -270,16 +270,18 @@
         "gn:id":7090954,
         "gp:id":2344720,
         "hasc:id":"BH.CP",
+        "iso:code":"BH-13",
         "iso:id":"BH-13",
         "qs_pg:id":1134915,
         "unlc:id":"BH-13",
         "wd:id":"Q528953"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a0a7d2acbab937545bff944a12c0e3c",
+    "wof:geomhash":"7f3ae3d738992d597f5b615071414855",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857381,
+    "wof:lastmodified":1695884405,
     "wof:name":"Capital",
     "wof:parent_id":85632167,
     "wof:placetype":"region",

--- a/data/856/690/59/85669059.geojson
+++ b/data/856/690/59/85669059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005866,
-    "geom:area_square_m":65048805.760276,
+    "geom:area_square_m":65048679.724057,
     "geom:bbox":"50.576366,26.178834,50.720622,26.331343",
     "geom:latitude":26.261095,
     "geom:longitude":50.642649,
@@ -300,15 +300,17 @@
         "gn:id":290333,
         "gp:id":2344724,
         "hasc:id":"BH.MU",
+        "iso:code":"BH-15",
         "iso:id":"BH-15",
         "qs_pg:id":1251493,
         "wd:id":"Q375630"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BH",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8f24ebda5b610eb2cdfc2cc74d957279",
+    "wof:geomhash":"4fe7b5212e0d37484bd80f8f23a805f1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857381,
+    "wof:lastmodified":1695884405,
     "wof:name":"Muharraq",
     "wof:parent_id":85632167,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.